### PR TITLE
Rewrite weather scaffold in C++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ temp/
 stl/
 .vs/
 FluidX3D.vcxproj.user
+target/
+weather/weather_sim
+weather/tests/config_test

--- a/weather/config.cpp
+++ b/weather/config.cpp
@@ -1,0 +1,51 @@
+#include "config.hpp"
+#include <fstream>
+#include <regex>
+#include <stdexcept>
+#include <string>
+
+namespace {
+std::string trim(const std::string& s) {
+    const auto start = s.find_first_not_of(" \t");
+    if (start == std::string::npos) return "";
+    const auto end = s.find_last_not_of(" \t");
+    return s.substr(start, end - start + 1);
+}
+}
+
+Config load_config(const std::string& path) {
+    Config cfg;
+    std::ifstream file(path);
+    if (!file) {
+        throw std::runtime_error("Failed to open config: " + path);
+    }
+    std::string line;
+    std::regex domain_re(R"(domain_size\s*=\s*\[(\d+),\s*(\d+),\s*(\d+)\])");
+    std::regex float_re(R"((\w+)\s*=\s*([0-9]*\.?[0-9]+))");
+    std::regex bool_re(R"((\w+)\s*=\s*(true|false))");
+    std::regex string_re(R"regex((\w+)\s*=\s*"([^"]*)")regex");
+    std::regex int_re(R"((\w+)\s*=\s*(\d+))");
+    while (std::getline(file, line)) {
+        line = trim(line);
+        if (line.empty() || line[0] == '#') continue;
+        std::smatch m;
+        if (std::regex_match(line, m, domain_re)) {
+            cfg.domain_size = {std::stoi(m[1]), std::stoi(m[2]), std::stoi(m[3])};
+        } else if (std::regex_match(line, m, float_re) && m[1] == "timestep") {
+            cfg.timestep = std::stod(m[2]);
+        } else if (std::regex_match(line, m, bool_re) && m[1] == "use_gfs") {
+            cfg.use_gfs = (m[2] == "true");
+        } else if (std::regex_match(line, m, string_re)) {
+            std::string key = m[1];
+            std::string val = m[2];
+            if (key == "gfs_file") cfg.gfs_file = val;
+            else if (key == "radiosonde_file") cfg.radiosonde_file = val;
+            else if (key == "aws_file") cfg.aws_file = val;
+            else if (key == "terrain_file") cfg.terrain_file = val;
+            else if (key == "output_dir") cfg.output_dir = val;
+        } else if (std::regex_match(line, m, int_re) && m[1] == "run_steps") {
+            cfg.run_steps = std::stoi(m[2]);
+        }
+    }
+    return cfg;
+}

--- a/weather/config.cpp
+++ b/weather/config.cpp
@@ -32,7 +32,11 @@ Config load_config(const std::string& path) {
         if (std::regex_match(line, m, domain_re)) {
             cfg.domain_size = {std::stoi(m[1]), std::stoi(m[2]), std::stoi(m[3])};
         } else if (std::regex_match(line, m, float_re) && m[1] == "timestep") {
-            cfg.timestep = std::stod(m[2]);
+        } else if (std::regex_match(line, m, float_re)) {
+            auto it = float_fields.find(m[1]);
+            if (it != float_fields.end()) {
+                *(it->second) = std::stod(m[2]);
+            }
         } else if (std::regex_match(line, m, bool_re) && m[1] == "use_gfs") {
             cfg.use_gfs = (m[2] == "true");
         } else if (std::regex_match(line, m, string_re)) {

--- a/weather/config.hpp
+++ b/weather/config.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <array>
+#include <string>
+
+struct Config {
+    std::array<int,3> domain_size{};
+    double timestep{};
+    bool use_gfs{};
+    std::string gfs_file;
+    std::string radiosonde_file;
+    std::string aws_file;
+    std::string terrain_file;
+    std::string output_dir;
+    int run_steps{};
+};
+
+Config load_config(const std::string& path);

--- a/weather/config.toml
+++ b/weather/config.toml
@@ -1,0 +1,9 @@
+domain_size = [100, 100, 60]
+timestep = 1.0
+use_gfs = true
+gfs_file = "data/gfs_20250806.grib2"
+radiosonde_file = "data/oakey_sounding.txt"
+aws_file = "data/brookstead_aws.csv"
+terrain_file = "data/terrain.png"
+output_dir = "output/"
+run_steps = 3600

--- a/weather/grid.cpp
+++ b/weather/grid.cpp
@@ -1,7 +1,23 @@
 #include "grid.hpp"
 
 Grid::Grid(const std::array<int,3>& size_) : size(size_) {
-    std::size_t N = static_cast<std::size_t>(size[0]) * size[1] * size[2];
+#include <limits>
+#include "grid.hpp"
+
+Grid::Grid(const std::array<int,3>& size_) : size(size_) {
+    // Check for overflow before multiplying
+    std::size_t s0 = static_cast<std::size_t>(size[0]);
+    std::size_t s1 = static_cast<std::size_t>(size[1]);
+    std::size_t s2 = static_cast<std::size_t>(size[2]);
+    std::size_t max = std::numeric_limits<std::size_t>::max();
+    if (s1 != 0 && s0 > max / s1) {
+        throw std::overflow_error("Grid dimension overflow (size[0] * size[1])");
+    }
+    std::size_t prod01 = s0 * s1;
+    if (s2 != 0 && prod01 > max / s2) {
+        throw std::overflow_error("Grid dimension overflow (size[0] * size[1] * size[2])");
+    }
+    std::size_t N = prod01 * s2;
     u.assign(N, 0.0);
     v.assign(N, 0.0);
     w.assign(N, 0.0);

--- a/weather/grid.cpp
+++ b/weather/grid.cpp
@@ -1,0 +1,8 @@
+#include "grid.hpp"
+
+Grid::Grid(const std::array<int,3>& size_) : size(size_) {
+    std::size_t N = static_cast<std::size_t>(size[0]) * size[1] * size[2];
+    u.assign(N, 0.0);
+    v.assign(N, 0.0);
+    w.assign(N, 0.0);
+}

--- a/weather/grid.hpp
+++ b/weather/grid.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <array>
+#include <vector>
+
+struct Grid {
+    std::array<int,3> size;
+    std::vector<double> u, v, w;
+    explicit Grid(const std::array<int,3>& size);
+};

--- a/weather/io/aws.cpp
+++ b/weather/io/aws.cpp
@@ -1,0 +1,7 @@
+#include "aws.hpp"
+
+namespace io {
+void ingest_aws(const std::string& path) {
+    // TODO: implement AWS surface data ingestion
+}
+}

--- a/weather/io/aws.hpp
+++ b/weather/io/aws.hpp
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+namespace io {
+void ingest_aws(const std::string& path);
+}

--- a/weather/io/gfs.cpp
+++ b/weather/io/gfs.cpp
@@ -1,0 +1,7 @@
+#include "gfs.hpp"
+
+namespace io {
+void load_gfs(const std::string& path) {
+    // TODO: implement GFS GRIB2 reading
+}
+}

--- a/weather/io/gfs.hpp
+++ b/weather/io/gfs.hpp
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+namespace io {
+void load_gfs(const std::string& path);
+}

--- a/weather/io/output.cpp
+++ b/weather/io/output.cpp
@@ -1,0 +1,7 @@
+#include "output.hpp"
+
+namespace io {
+void write_output(const std::string& dir) {
+    // TODO: implement NetCDF/HDF5 output
+}
+}

--- a/weather/io/output.hpp
+++ b/weather/io/output.hpp
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+namespace io {
+void write_output(const std::string& dir);
+}

--- a/weather/io/radiosonde.cpp
+++ b/weather/io/radiosonde.cpp
@@ -1,0 +1,7 @@
+#include "radiosonde.hpp"
+
+namespace io {
+void ingest_radiosonde(const std::string& path) {
+    // TODO: implement radiosonde parsing
+}
+}

--- a/weather/io/radiosonde.hpp
+++ b/weather/io/radiosonde.hpp
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+namespace io {
+void ingest_radiosonde(const std::string& path);
+}

--- a/weather/main.cpp
+++ b/weather/main.cpp
@@ -1,0 +1,31 @@
+#include "config.hpp"
+#include "grid.hpp"
+#include "terrain.hpp"
+#include "physics/thermal.hpp"
+#include "physics/cloud.hpp"
+#include "io/gfs.hpp"
+#include "io/radiosonde.hpp"
+#include "io/aws.hpp"
+#include "io/output.hpp"
+#include <iostream>
+
+int main() {
+    Config cfg = load_config("config.toml");
+    Grid grid(cfg.domain_size);
+    load_terrain(cfg.terrain_file);
+    if (cfg.use_gfs) {
+        io::load_gfs(cfg.gfs_file);
+    }
+    io::ingest_radiosonde(cfg.radiosonde_file);
+    io::ingest_aws(cfg.aws_file);
+
+    for (int step = 0; step < cfg.run_steps; ++step) {
+        physics::apply_thermal_buoyancy();
+        physics::update_cloud_microphysics();
+        if (step % 100 == 0) {
+            io::write_output(cfg.output_dir);
+        }
+    }
+    std::cout << "Simulation complete" << std::endl;
+    return 0;
+}

--- a/weather/physics/cloud.cpp
+++ b/weather/physics/cloud.cpp
@@ -1,0 +1,7 @@
+#include "cloud.hpp"
+
+namespace physics {
+void update_cloud_microphysics() {
+    // TODO: implement cloud microphysics
+}
+}

--- a/weather/physics/cloud.hpp
+++ b/weather/physics/cloud.hpp
@@ -1,0 +1,4 @@
+#pragma once
+namespace physics {
+void update_cloud_microphysics();
+}

--- a/weather/physics/thermal.cpp
+++ b/weather/physics/thermal.cpp
@@ -1,0 +1,7 @@
+#include "thermal.hpp"
+
+namespace physics {
+void apply_thermal_buoyancy() {
+    // TODO: implement buoyancy effects
+}
+}

--- a/weather/physics/thermal.hpp
+++ b/weather/physics/thermal.hpp
@@ -1,0 +1,4 @@
+#pragma once
+namespace physics {
+void apply_thermal_buoyancy();
+}

--- a/weather/terrain.cpp
+++ b/weather/terrain.cpp
@@ -1,0 +1,5 @@
+#include "terrain.hpp"
+
+void load_terrain(const std::string& path) {
+    // TODO: implement terrain loading
+}

--- a/weather/terrain.hpp
+++ b/weather/terrain.hpp
@@ -1,0 +1,3 @@
+#pragma once
+#include <string>
+void load_terrain(const std::string& path);

--- a/weather/tests/config_test.cpp
+++ b/weather/tests/config_test.cpp
@@ -1,0 +1,14 @@
+#include "../config.hpp"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    Config cfg = load_config("weather/config.toml");
+    assert(cfg.domain_size[0] == 100);
+    assert(cfg.domain_size[2] == 60);
+    assert(cfg.timestep == 1.0);
+    assert(cfg.use_gfs);
+    assert(cfg.run_steps == 3600);
+    std::cout << "config test passed" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace Rust-based weather module with C++ scaffold
- add configuration parser and grid container
- stub out physics and I/O modules with a driver loop

## Testing
- `g++ -std=c++17 weather/config.cpp weather/grid.cpp weather/terrain.cpp weather/physics/thermal.cpp weather/physics/cloud.cpp weather/io/gfs.cpp weather/io/radiosonde.cpp weather/io/aws.cpp weather/io/output.cpp weather/main.cpp -Iweather -o weather/weather_sim`
- `g++ -std=c++17 weather/config.cpp weather/tests/config_test.cpp -Iweather -o weather/tests/config_test`
- `weather/tests/config_test`


------
https://chatgpt.com/codex/tasks/task_e_68941d2db3608321889ed044e60b65fe