### PR TITLE
Fix config parsing and grid initialization

### DIFF
--- a/weather/config.cpp
+++ b/weather/config.cpp
@@ -32,11 +32,7 @@ Config load_config(const std::string& path) {
         if (std::regex_match(line, m, domain_re)) {
             cfg.domain_size = {std::stoi(m[1]), std::stoi(m[2]), std::stoi(m[3])};
         } else if (std::regex_match(line, m, float_re) && m[1] == "timestep") {
-        } else if (std::regex_match(line, m, float_re)) {
-            auto it = float_fields.find(m[1]);
-            if (it != float_fields.end()) {
-                *(it->second) = std::stod(m[2]);
-            }
+            cfg.timestep = std::stod(m[2]);
         } else if (std::regex_match(line, m, bool_re) && m[1] == "use_gfs") {
             cfg.use_gfs = (m[2] == "true");
         } else if (std::regex_match(line, m, string_re)) {

--- a/weather/grid.cpp
+++ b/weather/grid.cpp
@@ -1,8 +1,6 @@
 #include "grid.hpp"
-
-Grid::Grid(const std::array<int,3>& size_) : size(size_) {
 #include <limits>
-#include "grid.hpp"
+#include <stdexcept>
 
 Grid::Grid(const std::array<int,3>& size_) : size(size_) {
     // Check for overflow before multiplying


### PR DESCRIPTION
## Summary
- Parse `timestep` in `load_config` and remove undefined float field handling.
- Reimplement `Grid` constructor with overflow checks and clean initialization.

## Testing
- `g++ -std=c++17 weather/config.cpp weather/tests/config_test.cpp -o config_test && ./config_test`
- `g++ -std=c++17 weather/main.cpp weather/config.cpp weather/grid.cpp weather/terrain.cpp weather/io/aws.cpp weather/io/gfs.cpp weather/io/output.cpp weather/io/radiosonde.cpp weather/physics/thermal.cpp weather/physics/cloud.cpp -Iweather -o weather_sim && (cd weather && ../weather_sim)`

------
https://chatgpt.com/codex/tasks/task_e_68c35dd391288321a5e9a6d1d67aa10d